### PR TITLE
build: provide a dockerfile for ease of building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:lts-alpine as builder
+WORKDIR /src
+COPY package.json package-lock.json /src/
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /src/dist/gloomhavensecretary /usr/share/nginx/html
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ To selfhost *Gloomhaven Secretary* on your webserver, simple download the zip fi
 
 If you want to create you own custom build (for example to [selfhost](#selfhost)), prepare a [development setup](#development). Afterwards run `npm run build` ([available options](https://angular.io/cli/build#options)) and access build under `./dist/gloomhavensecretary`.
 
+## Build from source using Docker
+
+If you want to use docker to build, simply have docker installed and configured and do the following:
+
+```shell
+docker build -t gloomhavensecretary .
+docker run --rm -p 80:80 gloomhavensecretary
+```
+
 ## Development
 
 Prerequisite:
@@ -112,6 +121,8 @@ Checkout the source code with `git clone https://github.com/Lurkars/gloomhavense
 Install dependencies with `npm install`.
 
 Afterwards run `npm run start` to create a development server at [http://localhost:4200](http://localhost:4200).
+
+Alternatively, you can use docker (see the [docker instructions](#build-from-source-using-docker)).
 
 ## Contributing
 


### PR DESCRIPTION
Provides a basic dockerfile to ease development for those who would prefer to use this. It uses the latest LTS release from node's docker repository. That means we will currently build with nodejs version 16.17.1.

It would be best to use a specific version here but perhaps that's a thing to do later if we configure an updater to automatically merge the latest LTS version.