### PR TITLE
feat() : new labels translated

### DIFF
--- a/data/gh/label.json
+++ b/data/gh/label.json
@@ -596,7 +596,7 @@
       "tinkerer": "Bricoleur"
     },
     "edition": {
-      "gh": "Gloomhaven - Aventures à Havrenuit"
+      "gh": "Gloomhaven"
     },
     "monster": {
       "ancient-artillery": "Canon Ancien",

--- a/data/solo/label.json
+++ b/data/solo/label.json
@@ -41,5 +41,67 @@
         }
       }
     }
+  },
+  "fr": {
+    "edition": {
+      "solo": "Scénarios solo (toutes éditions)"
+    },
+    "monster": {
+      "bandit-archer-music-note-solo": "%data.monster.bandit-archer% (%data.character.music-note% %solo%)",
+      "bandit-guard-music-note-solo": "%data.monster.bandit-guard% (%data.character.music-note% %solo%)",
+      "cave-bear-circles-solo": "%data.monster.cave-bear% (%data.character.circles% %solo%)",
+      "city-guard-saw-solo": "%data.monster.city-guard% (%data.character.saw% %solo%)",
+      "city-guard-scoundrel-solo": "%data.monster.city-guard% (%data.character.scoundrel% %solo%)",
+      "city-guard-sun-solo": "%data.monster.city-guard% (%data.character.sun% %solo%)",
+      "city-guard-tinkerer-solo": "%data.monster.city-guard% (%data.character.tinkerer% %solo%)",
+      "deep-earth": "Terre Profonde",
+      "earth-demon-diviner-solo": "%data.monster.earth-demon% (%data.character.diviner% %solo%)",
+      "earth-demon-mindthief-solo": "%data.monster.earth-demon% (%data.character.mindthief% %solo%)",
+      "ghost-wolf": "Loup Fantôme",
+      "giant-viper-angry-face-solo": "%data.monster.giant-viper% (%data.character.angry-face% %solo%)",
+      "high-flame": "Haute Flamme",
+      "inox-necromancer": "Nécromancien Inox",
+      "lieutenant": "Lieutenant",
+      "song-of-the-deep": "Chanson des Profondeurs",
+      "stone-golem-scoundrel-solo": "%data.monster.stone-golem% (%data.character.scoundrel% %solo%)",
+      "vermling-scout-mindthief-solo": "%data.monster.vermling-scout% (%data.character.mindthief% %solo%)"
+    },
+    "scenario": {
+      "group": {
+        "solo": "Scénarios solo"
+      },
+      "Return to the Black Barrow": "Retour au Tertre Noir",
+      "An Unfortunate Intrusion": "Une Intrustion Mavenue",
+      "Corrupted Laboratory": "Le Laboratoire Corrompu",
+      "Armory Heist": "Casse à l'Armurerie",
+      "Stone Defense": "Une Défense de Pierre",
+      "Rodent Liberation": "La Libération des Rongeurs",
+      "Caravan Escort": "L'Escorte de la Caravane",
+      "Unnatural Insults": "Insultes Anormales",
+      "Storage Fees": "Frais de Stockage",
+      "Plane of Wild Beasts": "La Dimension des Bêtes Sauvages",
+      "Harvesting the Night": "Récolte Nocturne",
+      "Plagued Crypt": "La Crypte Pesteuse",
+      "Battle of the Bards": "La Bataille des Bardes",
+      "Corrupted Hunt": "Chasse Perverse",
+      "Aftermath": "Conséquences",
+      "Elemental Secrets": "Les Secrets Élémentaires",
+      "The Caged Bear": "L'Ours en Cage",
+      "The Sands of Time": "Les Sables du Temps",
+      "Forecast of the Inevitable": "Un Aperçu de l'Inévitable"
+    },
+    "custom": {
+      "solo": {
+        "char-am-deck": "Utilise le paquet de modificateur d'attaque du personnage"
+      },
+      "gh": {
+        "city-guard-sun-solo": {
+          "1": "Suffer 1 damage at end of round until fully healed"
+        },
+        "city-guard-saw-solo": {
+          "1": "Subit 1 dégât à la fin de chaque round tant qu'il n'a pas récupéré tous ses PV"
+        }
+      }
+    }
   }
 }

--- a/data/solo/scenarios.json
+++ b/data/solo/scenarios.json
@@ -327,7 +327,7 @@
   },
   {
     "index": "0",
-    "name": "Forecast of the Inevitable",
+    "name": "Un Aperçu de l'Inévitable",
     "edition": "fc",
     "group": "solo",
     "initial": true,

--- a/data/solo/scenarios.json
+++ b/data/solo/scenarios.json
@@ -327,7 +327,7 @@
   },
   {
     "index": "0",
-    "name": "Un Aperçu de l'Inévitable",
+    "name": "Forecast of the Inevitable",
     "edition": "fc",
     "group": "solo",
     "initial": true,

--- a/data/sox/label.json
+++ b/data/sox/label.json
@@ -18,25 +18,25 @@
       "tormented-soul": "Gequälte Seele",
       "water-eel": "Wasseraal"
     },
-    "scenario" : {
-      "Nobles' Crypt" : "Adelsgruft",
-      "Flooded Crypt" : "Überflutete Krypta",
-      "Crypt of the Ancients" : "Krypta der Ältesten"
+    "scenario": {
+      "Nobles' Crypt": "Adelsgruft",
+      "Flooded Crypt": "Überflutete Krypta",
+      "Crypt of the Ancients": "Krypta der Ältesten"
     }
   },
   "fr": {
     "edition": {
-      "sox": "Chercheur de Xor"
+      "sox": "Chercheur de Xorn"
     },
     "monster": {
       "night-demon-sox": "%data.monster.night-demon% (%data.edition.sox%)",
       "tormented-soul": "Âme tourmentée",
       "water-eel": "Anguille d'eau"
     },
-    "scenario" : {
-      "Nobles' Crypt" : "Crypte des nobles",
-      "Flooded Crypt" : "Crypte inondée",
-      "Crypt of the Ancients" : "Crypte des Anciens"
+    "scenario": {
+      "Nobles' Crypt": "Crypte des nobles",
+      "Flooded Crypt": "Crypte Inondée",
+      "Crypt of the Ancients": "Crypte des Anciens"
     }
   }
 }

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -500,7 +500,7 @@
     "spoilers": "Manage Spoilers",
     "editionDataUrls": {
       ".": "Manage Edition Data",
-      "enable" : "Enable Edition",
+      "enable": "Enable Edition",
       "disable": "Disable Edition",
       "remove": "Remove Edition Data",
       "custom": "Additional Edition Data"

--- a/src/assets/locales/fr.json
+++ b/src/assets/locales/fr.json
@@ -39,11 +39,12 @@
       "addMonster": "Ajouter monstre {0}",
       "addNextStandee": "Ajouter {1} {0} silhouette",
       "addObjective": "Ajouter objectif {0}",
-      "addParty": "Créer de nouvelles compagnie '{0}'",
+      "addParty": "Créer une nouvelle compagnie '{0}'",
       "addRandomStandee": "Ajouter {1} {0} silhouette aléatoire {2}",
       "addSection": "Ajouter section #{0} {1} ({2})",
       "addStandee": "Ajout {0} n°{2} ({1})",
       "addSummon": "Ajouter invocation '{1}' pour {0}",
+      "addTreasure": "Ajout trésor {1} '%data.treasures.{0}.{1}%' (%data.edition.{0}%)",
       "applyCondition": {
         "char": "Appliquer {1} to {0}",
         "objective": "Appliquer {1} to {0}",
@@ -61,7 +62,7 @@
       "changeObjectiveHP": "PV {1} pour objectif {0}",
       "changeObjectiveId": "ID '{1}' pour {0}",
       "changeObjectiveMaxHP": "Max. PV {1} pour objectif {0}",
-      "changeParty": "Changer de compagnie en '{0}'",
+      "changeParty": "Changer compagnie en '{0}'",
       "changeSummonAttack": "Attaque {2} pour invocation '{1}' de {0}",
       "changeSummonHp": "PV {2} pour invocation '{1}' de {0}",
       "changeSummonMaxHp": "Max. PV {2} pour invocation '{1}' de {0}",
@@ -116,7 +117,8 @@
       "removeManualScenario": "Retrait du scénario #{0} {1} ({2})",
       "removeMonster": "Retrait du monstre {0}",
       "removeObjective": "Retrait de l'objectif {0}",
-      "removeParty": "Retirer de compagnie '{0}'",
+      "removeParty": "Retrait de la compagnie '{0}'",
+      "removeTreasure": "Retrait trésor {1} '%data.treasures.{0}.{1}%' (%data.edition.{0}%)",
       "reorder": "Réarranger les figurines",
       "reorderAbilities": "Réarranger les capacités de {0}",
       "resetScenario": "Redémarrer le scénario #{0} {1} ({2})",
@@ -217,7 +219,7 @@
       "name": "%character%",
       "loot": "Pillage",
       "gold": "Or",
-      "totalGold": "Total Gold",
+      "totalGold": "Or total",
       "xpGained": "Gain d'expérience",
       "xpBonus": "Expérience bonus",
       "xp": "Expérience",
@@ -310,8 +312,8 @@
     "reputation": "Réputation",
     "prosperity": "Prosperité",
     "campaignMode": "Mode Campagne",
-    "new": "Créer de nouvelles compagnie",
-    "remove": "Retirer de compagnie",
+    "new": "Créer une nouvelle compagnie",
+    "remove": "Retirer la compagnie",
     "change": "Changer de compagnie",
     "shop": {
       ".": "Modificateur de prix",
@@ -322,6 +324,7 @@
     "campaign": {
       ".": "Campagne",
       "achievements": "Hauts Faits généraux",
+      "treasures": "Trésors",
       "donations": "Donations au Sanctuaire du Grand Chêne",
       "scenarios": {
         ".": "Scénarios",
@@ -397,7 +400,7 @@
     },
     "fullscreen": "Plein écran",
     "fhStyle": "Style Frosthaven (%wip%)",
-    "hideAbsent": "Cacher absent figurines",
+    "hideAbsent": "Cacher les figurines absentes",
     "autoscroll": "Défilement automatique",
     "disableColumns": "Désactiver affichage en colonnes",
     "dragValues": "Glisser pour modifier Initiative/HP/XP/Loot",
@@ -414,6 +417,10 @@
       "en": "Anglais (English)",
       "de": "Allemand (Deutsch)",
       "fr": "Français"
+    },
+    "debug": {
+      ".": "Paramètres de debug",
+      "rightClick": "Toujour activer le clic droit"
     }
   },
   "server": {
@@ -490,10 +497,10 @@
   },
   "datamanagement": {
     ".": "Gestion des données",
-    "spoilers": "Gérer les spoilers",    
+    "spoilers": "Gérer les spoilers",
     "editionDataUrls": {
       ".": "Gérer les données des éditions",
-      "enable" : "Activer l'édition",
+      "enable": "Activer l'édition",
       "disable": "Désactiver l'édition",
       "remove": "Retrait les données des éditions",
       "custom": "Les données des éditions supplémentaire"
@@ -661,7 +668,8 @@
       "edit": "Éditer",
       "restore": "Restaurer les cartes par défaut",
       "defaultSort": "Trier",
-      "openDialog": "Montrer toutes les cartes"
+      "openDialog": "Montrer toutes les cartes",
+      "fullscreen": "Montrer en plein écran"
     },
     "attackModifiers": {
       ".": "Paquet de Modificateur d'Attaque",


### PR DESCRIPTION
Hi @Lurkars !

I translated some of the new labels added. Did not translate everything from CS (since the game is only in English for now it's better to let the names match), and also did not translate the treasures (will look into it later).

A few remarks : 

- In data/solo/label.json, there is "Suffer 1 damage at end of round until fully healed" for the Sun solo scenario, however it seems that it is only used for the Saw solo scenario.
- Could you use some placeholder for the Ghost Wolf's "at the start of each round" values ? 
- There is a strange bug for perks in French when the perk comes with an "and" : the first "card" word is not translated. To check it, please look at the third perk of the Cragheart in French : it says "Ajouter une card et deux cartes +2 -2" instead of "Ajouter une carte -2 et deux cartes +2". The issue seems to lie in the perkLabel function but I can't find it (I only know bash and C++ ^^), could you please look into it ?
- Finally, a minor remark : In French, the race and the class name are inverted in the character sheet. Is it possible to have a boolean that rules it for French and other languages that may also require this ?
 
Thank you !